### PR TITLE
Fix hosts entry

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,20 @@
 - name: Add host entry
   lineinfile:
     dest=/etc/hosts
-    regexp=" {{ ansible_hostname }} "
+    regexp="^{{ ansible_default_ipv4.address }}"
     line="{{ ansible_default_ipv4.address }} {{ ansible_fqdn }}"
     owner=root
     group=root
     mode=0644
+
+- name: Remove loopback addresses on fqdn in /etc/hosts
+  lineinfile:
+    dest=/etc/hosts
+    regexp="^(127\.0\.0\.1)|(\:\:1).* {{ ansible_fqdn }}"
+    owner=root
+    group=root
+    mode=0644
+    state=absent
 
 - name: Ensure software is installed (yum)
   yum: name={{ item }} state=present


### PR DESCRIPTION
Sometimes, the distribution adds loopback addresses as resolve of the
fqdn, and FreeIPA doesn't like that.

Secondly, the regex match for public address on hosts file didn't work
as intended.